### PR TITLE
Fixes to allow compilation on Mac OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,10 @@ src/app/debug
 src/app/release
 src/unittest/debug
 src/unittest/release
+
+# Mac OS X
+.DS_Store
+
+# default build directory
+bin
+

--- a/src/hrlib/math/brent.cpp
+++ b/src/hrlib/math/brent.cpp
@@ -5,6 +5,7 @@
 ****************************************************************************/
 
 # include <iostream>
+# include <cmath>
 # include <qmath.h>
 # include <numeric>
 

--- a/src/patheditor/path.cpp
+++ b/src/patheditor/path.cpp
@@ -181,6 +181,9 @@ void Path::onPathReleased()
 namespace patheditor {
     class PathSerializer : public jenson::JenSON::CustomSerializer<Path>
     {
+    public:
+      PathSerializer(void) {}
+
     protected:
         virtual QJsonValue serializeImpl(const Path *object) const override;
         virtual sptr<Path> deserializeImpl(const QJsonValue *jsonValue, QString *errorMsg) const override;


### PR DESCRIPTION
Two fixes and a few additional ignorable targets.
Compilation performed on Mac OS X 10.9.5 with
- cmake @3.0.2_1
- boost @1.56.0_1
- qt5-mac @5.3.2
Executable at https://dl.dropboxusercontent.com/u/343465/finFoil
