### PR TITLE
two fixes to make finFoil compile on Mac OS X

### DIFF
--- a/src/hrlib/math/brent.cpp
+++ b/src/hrlib/math/brent.cpp
@@ -5,6 +5,7 @@
 ****************************************************************************/
 
 # include <iostream>
+# include <cmath>
 # include <qmath.h>
 # include <numeric>
 

--- a/src/patheditor/path.cpp
+++ b/src/patheditor/path.cpp
@@ -181,6 +181,9 @@ void Path::onPathReleased()
 namespace patheditor {
     class PathSerializer : public jenson::JenSON::CustomSerializer<Path>
     {
+    public:
+      PathSerializer(void) {}
+
     protected:
         virtual QJsonValue serializeImpl(const Path *object) const override;
         virtual sptr<Path> deserializeImpl(const QJsonValue *jsonValue, QString *errorMsg) const override;


### PR DESCRIPTION
1. std:abs was ambiguous
   => included standard cmath before qmath.h
2. default initialization of an object of const
   type 'const patheditor::PathSerializer'
   requires a user-provided default constructor
   => added empty constructor