### PR TITLE
App Bundle with Qt5 dylibs included

### DIFF
--- a/scripts/fix-plugins.sh
+++ b/scripts/fix-plugins.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# script expects to be execute from the bundle directory (e.g. finFoil.app/)
+# it takes two arguments:
+LIBQCOCOA_DYLIB=$1
+FRAMEWORKS_PATH=$2
+
+# install libqcocoa plugin
+mkdir -p Contents/PlugIns/platforms
+cp ${LIBQCOCOA_DYLIB} Contents/PlugIns/platforms
+
+# fix identity and references to frameworks
+install_name_tool -id @executable_path/../PlugIns/platforms/libqcocoa.dylib Contents/PlugIns/platforms/libqcocoa.dylib
+install_name_tool -change ${FRAMEWORKS_PATH}/QtPrintSupport.framework/Versions/5/QtPrintSupport @executable_path/../Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport Contents/PlugIns/platforms/libqcocoa.dylib
+install_name_tool -change ${FRAMEWORKS_PATH}/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets Contents/PlugIns/platforms/libqcocoa.dylib
+install_name_tool -change ${FRAMEWORKS_PATH}/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui Contents/PlugIns/platforms/libqcocoa.dylib
+install_name_tool -change ${FRAMEWORKS_PATH}/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore Contents/PlugIns/platforms/libqcocoa.dylib
+
+# install QtPrintSupport framework
+cp -r ${FRAMEWORKS_PATH}/QtPrintSupport.framework Contents/Frameworks
+
+# fix identity and references to frameworks
+install_name_tool -id @executable_path/../Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport Contents/Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport
+install_name_tool -change ${FRAMEWORKS_PATH}/QtWidgets.framework/Versions/5/QtWidgets @executable_path/../Frameworks/QtWidgets.framework/Versions/5/QtWidgets Contents/Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport
+install_name_tool -change ${FRAMEWORKS_PATH}/QtGui.framework/Versions/5/QtGui @executable_path/../Frameworks/QtGui.framework/Versions/5/QtGui Contents/Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport
+install_name_tool -change ${FRAMEWORKS_PATH}/QtCore.framework/Versions/5/QtCore @executable_path/../Frameworks/QtCore.framework/Versions/5/QtCore Contents/Frameworks/QtPrintSupport.framework/Versions/5/QtPrintSupport

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -25,8 +25,7 @@ set(HDR
 #
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
-add_executable(${BINARY_NAME} WIN32 ${SRC} ${HDR} ${MOC_SRC} ${FORMS_HEADERS} ${RC_SRC} ${QM})
-
+add_executable(${BINARY_NAME} WIN32 MACOSX_BUNDLE ${SRC} ${HDR} ${MOC_SRC} ${FORMS_HEADERS} ${RC_SRC} ${QM})
 
 #
 # Subdirectories
@@ -45,3 +44,56 @@ add_subdirectory(../../submodules/qtunits/src "${CMAKE_SOURCE_DIR}/submodules/qt
 #
 
 target_link_libraries(${BINARY_NAME} foileditors)
+
+# add enough libraries to the app bundle to allow stand-alone execution
+if (APPLE)
+  find_program(MACDEPLOYQT NAMES macdeployqt PATHS ${qt_base_dir}/bin)
+  if(NOT MACDEPLOYQT)
+      message(FATAL_ERROR "The utility 'macdeployqt' is required to create an App Bundle!")
+  endif()
+
+  # populate the app bundle with Qt(5) support using macdeployqt
+  add_custom_command(
+    TARGET ${BINARY_NAME}
+    POST_BUILD
+    COMMAND ${MACDEPLOYQT} ${BINARY_NAME}.app
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  )
+
+  # find out the location of libqcocoa.dylib
+  # current paths include: location via MacPort installation
+  # TODO: add more possible paths
+  set(libqcocoa_search_path
+    /opt/local/share/qt5/plugins/platforms  # MacPorts
+    /usr/local/share/qt5/plugins/platforms  # Homebrew (unverified)
+  )
+  find_library(LIBCOCOA NAMES libqcocoa.dylib PATHS ${libqcocoa_search_path})
+  if(NOT LIBCOCOA)
+      message(FATAL_ERROR "libqcocoa.dylib is required to create an App Bundle!")
+  endif()
+
+  # find out the location of the Frameworks
+  # current paths include: location via MacPort installation
+  # TODO: add more possible paths
+  set(frameworks_search_path
+    /opt/local/Library/Frameworks           # MacPorts
+    /usr/local/Library/Frameworks           # Homebrew (unverified)
+  )
+  find_library(QTPRINTSUPPORT_FW NAMES QtPrintSupport PATHS ${frameworks_search_path})
+  if(NOT QTPRINTSUPPORT_FW)
+      message(FATAL_ERROR "QtPrintSupport.framework is required to create an App Bundle!")
+  endif()
+  get_filename_component(FRAMEWORKS ${QTPRINTSUPPORT_FW} DIRECTORY)
+
+  # add dynamically loaded plugins, missing from the app bundle after prev cmd
+  add_custom_command(
+    TARGET ${BINARY_NAME}
+    POST_BUILD
+    COMMAND ../../scripts/fix-plugins.sh ${LIBCOCOA} ${FRAMEWORKS}
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${BINARY_NAME}.app
+  )
+
+  # export compile-time variable for conditional compilation in main.cpp of code
+  # to fix the library path, restricting it to the app bundle
+  add_definitions(-DEXECUTE_WITHIN_APP_BUNDLE)
+endif()

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -26,6 +26,8 @@
 #include <QApplication>
 #include <QCommandLineParser>
 
+#include <QDir>
+
 QTextStream out(stdout);
 QTextStream err(stderr);
 
@@ -36,6 +38,14 @@ int main(int argc, char *argv[])
 {
     try
     {
+#ifdef EXECUTE_WITHIN_APP_BUNDLE
+        // restricting library-path to bundle
+        QDir dir(argv[0]);          // e.g. appdir/Contents/MacOS/appname
+        assert(dir.cdUp());
+        assert(dir.cdUp());
+        assert(dir.cd("PlugIns"));  // e.g. appdir/Contents/PlugIns
+        QCoreApplication::setLibraryPaths(QStringList(dir.absolutePath()));
+#endif
         QApplication app(argc, argv);
         QApplication::setApplicationName("finFoil");
         QApplication::setApplicationVersion(version.toString());


### PR DESCRIPTION
Most work is done by macdeployqt, but for some
plugins, additional fixes are needed: libqcocoa is
dynamically loaded and isn’t detected by the tool.